### PR TITLE
Become fixes - Ansible is deprecating the 'sudo' naming in favor of 'become'

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,5 @@
   service:
     name:  "{{ jumpcloud_agent_service }}"
     state: restarted
+  become: "{{ jumpcloud_use_sudo }}"
 ...

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     owner:  "{{ jumpcloud_install_script_owner }}"
     group:  "{{ jumpcloud_install_script_group }}"
     mode:   "{{ jumpcloud_temp_directory_mode }}"
-  sudo: "{{ jumpcloud_use_sudo }}"
+  become: "{{ jumpcloud_use_sudo }}"
 
 - name: Copy the string into position
   template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,11 +30,13 @@
     owner:    "{{ jumpcloud_install_script_owner }}"
     group:    "{{ jumpcloud_install_script_group }}"
     mode:     "{{ jumpcloud_install_script_mode }}"
+  become: "{{ jumpcloud_use_sudo }}"
 
 - name:     Execute this via the shell
   command: "./{{ jumpcloud_temp_install_file }}"
   args:
     chdir: "{{ jumpcloud_temp_directory }}"
+  become: "{{ jumpcloud_use_sudo }}"
   notify:
     - restart JumpCloud
 ...


### PR DESCRIPTION
I updated to the newer syntax and also added become to a few other tasks since they execute remotely and potentially need sudo access. The new additions honor the existing `jumpcloud_use_sudo` flag.